### PR TITLE
Use minetest.conf to configure spawn rate of eggs & grass.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,6 +3,12 @@ local egg_chance = tonumber(minetest.settings:get('spawneggs.egg_chance')) or 30
 local grass_interval = tonumber(minetest.settings:get('spawneggs.grass_interval')) or 600
 local grass_chance = tonumber(minetest.settings:get('spawneggs.grass_chance')) or 3000
 
+-- Allow spawnegg nodes to spawn in world
+local enable_node_spawn = minetest.settings:get_bool('spawneggs.enable_node_spawn')
+if enable_node_spawn == nil then
+	enable_node_spawn = true
+end
+
 local spawneggs_list = {
 	{ "Spawn Dirt Monster", "dirt_monster", "default:dirt"},
 	{ "Spawn Dungeon Master", "dungeon_master", "default:mese"},	
@@ -71,15 +77,19 @@ minetest.register_craft({
     cooktime = 5,
 })
 
+
 -- Egg Spawning and De-spawning
-minetest.register_abm(
-	{nodenames = {"default:grass_1"},
-	interval = grass_interval,
-	chance = grass_chance,
-	action = function(pos)
-	minetest.env:add_node(pos, {name="spawneggs:egg"})
-	end,
-})
+
+if enable_node_spawn then
+	minetest.register_abm(
+		{nodenames = {"default:grass_1"},
+		interval = grass_interval,
+		chance = grass_chance,
+		action = function(pos)
+		minetest.env:add_node(pos, {name="spawneggs:egg"})
+		end,
+	})
+end
 
 minetest.register_abm(
 	{nodenames = {"spawneggs:egg"},

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
-local egg_interval = tonumber(minetest.settings:get('spawneggs_egg_interval')) or 600
-local egg_chance = tonumber(minetest.settings:get('spawneggs_egg_chance')) or 3000
-local grass_interval = tonumber(minetest.settings:get('spawneggs_grass_interval')) or 600
-local grass_chance = tonumber(minetest.settings:get('spawneggs_grass_chance')) or 3000
+local egg_interval = tonumber(minetest.settings:get('spawneggs.egg_interval')) or 600
+local egg_chance = tonumber(minetest.settings:get('spawneggs.egg_chance')) or 3000
+local grass_interval = tonumber(minetest.settings:get('spawneggs.grass_interval')) or 600
+local grass_chance = tonumber(minetest.settings:get('spawneggs.grass_chance')) or 3000
 
 local spawneggs_list = {
 	{ "Spawn Dirt Monster", "dirt_monster", "default:dirt"},

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,8 @@
+local egg_interval = tonumber(minetest.settings:get('spawneggs_egg_interval')) or 600
+local egg_chance = tonumber(minetest.settings:get('spawneggs_egg_chance')) or 3000
+local grass_interval = tonumber(minetest.settings:get('spawneggs_grass_interval')) or 600
+local grass_chance = tonumber(minetest.settings:get('spawneggs_grass_chance')) or 3000
+
 local spawneggs_list = {
 	{ "Spawn Dirt Monster", "dirt_monster", "default:dirt"},
 	{ "Spawn Dungeon Master", "dungeon_master", "default:mese"},	
@@ -69,8 +74,8 @@ minetest.register_craft({
 -- Egg Spawning and De-spawning
 minetest.register_abm(
 	{nodenames = {"default:grass_1"},
-	interval = 600,
-	chance = 3000,
+	interval = grass_interval,
+	chance = grass_chance,
 	action = function(pos)
 	minetest.env:add_node(pos, {name="spawneggs:egg"})
 	end,
@@ -78,10 +83,9 @@ minetest.register_abm(
 
 minetest.register_abm(
 	{nodenames = {"spawneggs:egg"},
-	interval = 600,
-	chance = 3000,
+	interval = egg_interval,
+	chance = egg_chance,
 	action = function(pos)
 	minetest.env:add_node(pos, {name="air"})
 	end,
 })
-

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,7 @@
+spawneggs.egg_interval (Spawn interval) int 600
+spawneggs.egg_chance (Spawn chance) int 3000
+spawneggs.grass_interval (Grass interval) int 600
+spawneggs.grass_chance (Grass chance) int 3000
+
+# Allow eggs to spawn randomly in the world.
+spawneggs.enable_node_spawn (Enable node spawn) bool true


### PR DESCRIPTION
Adds variables that check for 'spawneggs_egg_interval', 'spawneggs_egg_chance', 'spawneggs_grass_interval', & 'spawneggs_grass_chance' to set spawning rate for eggs & grass. If the settings are not found the default values are used:

`egg: interval = 600, chance = 3000`
`grass: interval = 600, chance = 3000`
